### PR TITLE
* useSetting模块：menu onClick的事件类型的正确声明；去掉无用的props声明

### DIFF
--- a/src/layouts/baseLayout/header/userSetting.tsx
+++ b/src/layouts/baseLayout/header/userSetting.tsx
@@ -1,13 +1,13 @@
 import React, { FC } from 'react';
 import { connect, Dispatch } from 'umi';
-import { ClickParam } from 'antd/es/menu';
+import { MenuInfo } from 'rc-menu/lib/interface';
 import { Dropdown, Menu } from 'antd';
 import {
   SettingOutlined,
   LogoutOutlined,
   DownOutlined,
 } from '@ant-design/icons';
-import { LoginModelState, GlobalModelState } from '@/models/connect';
+import { GlobalModelState } from '@/models/connect';
 
 export interface HeaderLayoutProps {
   dispatch: Dispatch;
@@ -15,7 +15,7 @@ export interface HeaderLayoutProps {
 }
 
 const UserSettingLayout: FC<HeaderLayoutProps> = ({ global, dispatch }) => {
-  function handleSubmit(event: ClickParam) {
+  function handleSubmit(event: MenuInfo) {
     const { key } = event;
     if (key === 'logout') {
       dispatch({
@@ -56,10 +56,8 @@ const UserSettingLayout: FC<HeaderLayoutProps> = ({ global, dispatch }) => {
 
 export default connect(
   ({
-    login,
     global,
   }: {
-    login: LoginModelState;
     global: GlobalModelState;
-  }) => ({ login, global }),
+  }) => ({ global }),
 )(UserSettingLayout);

--- a/src/layouts/baseLayout/menu/index.tsx
+++ b/src/layouts/baseLayout/menu/index.tsx
@@ -1,5 +1,5 @@
 import React, { FC } from 'react';
-import { Link, connect, useLocation, Loading } from 'umi';
+import { Link, connect, useLocation } from 'umi';
 import { Menu } from 'antd';
 import { GlobalModelState } from '@/models/connect';
 import { queryKeysByPath } from '@/utils/utils';
@@ -8,7 +8,6 @@ const { SubMenu, Item } = Menu;
 
 export interface BasicLayoutProps {
   global: GlobalModelState;
-  loading: boolean;
 }
 
 const MenuContent: FC<BasicLayoutProps> = ({ global }) => {
@@ -55,8 +54,7 @@ const MenuContent: FC<BasicLayoutProps> = ({ global }) => {
 };
 
 export default connect(
-  ({ global, loading }: { global: GlobalModelState; loading: Loading }) => ({
+  ({ global }: { global: GlobalModelState }) => ({
     global,
-    loading: loading.models.index,
   }),
 )(MenuContent);

--- a/src/models/connect.d.ts
+++ b/src/models/connect.d.ts
@@ -36,8 +36,8 @@ export interface MenusDate {
   children: any;
 }
 export interface LoginUserInfoState {
-  id: string;
-  name: string;
+  username: string;
+  userid: string;
   role?: string;
   [key: string]: any;
 }

--- a/src/models/dashboard.ts
+++ b/src/models/dashboard.ts
@@ -1,18 +1,24 @@
 import { Effect, Reducer, history } from 'umi';
-import { message } from 'antd';
 import { queryCard } from '@/services/dashboard';
-
-import { ConnectState } from './connect.d';
 
 export interface DashboardState {
   data: DataProps[];
-  cardSource: any;
+  cardSource: totalDataType;
 }
 
 interface DataProps {
   id: string;
   name: string;
 }
+
+export type totalDataType = {
+  headCount?: number;
+  surveyCount?: number;
+  totalCount?: number;
+  deadLine?: string;
+  rate?: string;
+  lossRate?: string;
+};
 
 export interface DashboardType {
   namespace: 'dashboard';

--- a/src/models/global.ts
+++ b/src/models/global.ts
@@ -29,8 +29,8 @@ const GlobalModel: GlobalModelType = {
     name: '',
     menusData: menusSource,
     userInfo: {
-      id: '',
-      name: '',
+      userid: '',
+      username: '',
     },
   },
   effects: {

--- a/src/models/login.ts
+++ b/src/models/login.ts
@@ -28,8 +28,8 @@ const LoginModel: LoginModelType = {
   namespace: 'login',
   state: {
     userInfo: {
-      id: '',
-      name: '',
+      userid: '',
+      username: '',
     },
     isError: false,
   },

--- a/src/models/queryTable.ts
+++ b/src/models/queryTable.ts
@@ -34,7 +34,7 @@ const QueryTableModel: QueryTableType = {
   effects: {
     *queryTableList(_, { call, put, select }) {
       const { searchContentVal, statusVal } = yield select(
-        (state: QueryTableState) => state,
+        (state: any) => state.queryTable,
       );
       const response = yield call(queryTableList, {
         searchContentVal,

--- a/src/pages/dashboard/components/visitCard/index.tsx
+++ b/src/pages/dashboard/components/visitCard/index.tsx
@@ -1,19 +1,13 @@
 import React, { FC, memo } from 'react';
 import { Row, Col, Tooltip, Skeleton } from 'antd';
+import { totalDataType } from '@/models/dashboard';
 import styles from '../../index.less';
 
 const userImg = require('@/assets/visit_user.png');
 const surveyImg = require('@/assets/visit_survey.png');
 const totalImg = require('@/assets/visit_total.png');
 
-type totalDataType = {
-  headCount?: number;
-  surveyCount?: number;
-  totalCount?: number;
-  deadLine?: string;
-  rate?: string;
-  lossRate?: string;
-};
+
 interface VisitCardProps {
   totalData: totalDataType;
   loading: boolean | undefined;

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,13 +1,11 @@
 import React, { FC } from 'react';
 import { connect, Dispatch } from 'umi';
 import { Row, Col } from 'antd';
-import { ConnectState } from '@/models/connect';
 import LoginForm from './components/loginForm';
 import styles from './index.less';
 
 export interface LoginLayoutProps {
   dispatch: Dispatch;
-  login: ConnectState;
   loading: boolean;
 }
 
@@ -17,6 +15,7 @@ export interface SubmitValProps {
 }
 
 const Login: FC<LoginLayoutProps> = ({ dispatch }) => {
+  
   function handleSubmit(values: SubmitValProps) {
     dispatch({
       type: 'login/queryLogin',
@@ -52,6 +51,4 @@ const Login: FC<LoginLayoutProps> = ({ dispatch }) => {
   );
 };
 
-export default connect(({ login }: { login: ConnectState }) => ({ login }))(
-  Login,
-);
+export default connect()(Login);


### PR DESCRIPTION
* 登录模块页面-去掉无用的props属性声明
* 登录模块/global模块：model中userInfo中属性的正确声明
* Menu模块：去掉无用的props声明
* dashboard模块：增加对cardSource数据的类型约束
* queryTable模块：“查询列表”搜索接口入参不正确的问题修复